### PR TITLE
Switch to 'AWS' and Default strings

### DIFF
--- a/src/tortuga/resourceAdapter/aws/aws.py
+++ b/src/tortuga/resourceAdapter/aws/aws.py
@@ -68,7 +68,7 @@ class Aws(ResourceAdapter):
     AWS resource adapter
 
     """
-    __adaptername__ = 'aws'
+    __adaptername__ = 'AWS'
 
     LAUNCH_INITIAL_SLEEP_TIME = 10.0
 

--- a/src/tortuga/scripts/list_spot_instance_nodes.py
+++ b/src/tortuga/scripts/list_spot_instance_nodes.py
@@ -34,6 +34,6 @@ def main():
     with DbManager().session() as session:
         for node in NodesDbHandler().getNodeList(session):
             if node.hardwareprofile.resourceadapter and \
-                    node.hardwareprofile.resourceadapter.name == 'aws':
+                    node.hardwareprofile.resourceadapter.name == 'AWS':
                 if node.name in spot_instances:
                     print(node.name)

--- a/src/tortuga/scripts/setup_aws.py
+++ b/src/tortuga/scripts/setup_aws.py
@@ -34,7 +34,7 @@ from tortuga.resourceAdapterConfiguration.api import \
 
 DEFAULT_AWS_REGION = 'us-east-1'
 
-DEFAULT_RESOURCE_ADAPTER_CONFIGURATION_PROFILE_NAME = 'default'
+DEFAULT_RESOURCE_ADAPTER_CONFIGURATION_PROFILE_NAME = 'Default'
 
 DEFAULT_INSTANCE_TYPE = 'm5.large'
 
@@ -620,7 +620,7 @@ def _update_resource_adapter_configuration(adapter_cfg, profile_name):
     # check for resource adapter configuration
     with DbManager().session() as session:
         try:
-            api.get(session, 'aws', profile_name)
+            api.get(session, 'AWS', profile_name)
 
             print_statement(
                 'Updating AWS resource adapter configuration profile [{0}]',
@@ -636,13 +636,13 @@ def _update_resource_adapter_configuration(adapter_cfg, profile_name):
                     'key': 'user_data_script_template', 'value': None
                 })
 
-            api.update(session, 'aws', profile_name, normalized_cfg)
+            api.update(session, 'AWS', profile_name, normalized_cfg)
         except ResourceNotFound:
             print_statement(
                 'Creating AWS resource adapter configuration profile [{0}]',
                 profile_name)
 
-            api.create(session, 'aws', profile_name, normalized_cfg)
+            api.create(session, 'AWS', profile_name, normalized_cfg)
 
 
 def get_resource_name_from_tag(subnet):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,7 +211,7 @@ def dbm():
         default_adapter.kit = kit
 
         # create resource adapter
-        aws_adapter = ResourceAdapter(name='aws')
+        aws_adapter = ResourceAdapter(name='AWS')
         aws_adapter.kit = ra_kit
 
         aws_adapter_cfg = ResourceAdapterConfig(
@@ -239,8 +239,8 @@ def dbm():
 
         session.add(aws_adapter)
 
-        # create 'aws' hardware profile
-        aws_hwprofile = HardwareProfile(name='aws')
+        # create 'AWS' hardware profile
+        aws_hwprofile = HardwareProfile(name='AWS')
         aws_hwprofile.location = 'remote'
         aws_hwprofile.resourceadapter = aws_adapter
 
@@ -267,7 +267,7 @@ def dbm():
                                              components=[core_component],
                                              type='compute')
 
-        # map 'aws' to 'compute'
+        # map 'AWS' to 'compute'
         aws_hwprofile.mappedsoftwareprofiles.append(compute_swprofile)
         aws_hwprofile2.mappedsoftwareprofiles.append(compute_swprofile)
 

--- a/tortuga_kits/awsadapter_6_3_1/kit.py
+++ b/tortuga_kits/awsadapter_6_3_1/kit.py
@@ -22,4 +22,4 @@ class AWSKitInstaller(ResourceAdapterMixin, KitInstallerBase):
         'aws-instances.csv',
     ]
     puppet_modules = ['univa-tortuga_kit_awsadapter']
-    resource_adapter_name = 'aws'
+    resource_adapter_name = 'AWS'


### PR DESCRIPTION
The Resource adapter name needs to be AWS and the default
profile needs to be Default so that it looks nice in
web uis.