### PR TITLE
Use the detected AMI for instance type validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ python:
 services:
 - docker
 env:
-- TORTUGA_BUILD_DOCKER="true"
+- TORTUGA_BUILD_DOCKER="true" BUILD_KIT_IMAGE="univa/tortuga-build-kit:7.0.3-devel-latest"
 before_install:
-- docker pull univa/tortuga-build-kit:7.0.3-devel-latest
+- docker pull $BUILD_KIT_IMAGE
 install:
 - chmod -R a-w .
-- docker run --rm -it -v `pwd`:/kit-src univa/tortuga-build-kit:master-latest
+- docker run --rm -it -v `pwd`:/kit-src $BUILD_KIT_IMAGE
 script:
 - echo "Done"
 deploy:

--- a/src/tortuga/scripts/setup_aws.py
+++ b/src/tortuga/scripts/setup_aws.py
@@ -470,7 +470,7 @@ def main(verbose, debug, no_autodetect, ignore_iam, unattended, region,
 
         # validate user-provided instance type
         result = validate_instance_type(
-            ec2, instance_type, subnet_id, debug=debug)
+            ec2, instance_type, ami_id, subnet_id, debug=debug)
         if result:
             print(colorama.Style.BRIGHT + colorama.Fore.GREEN +
                   'done.' + colorama.Style.RESET_ALL)
@@ -652,28 +652,8 @@ def get_resource_name_from_tag(subnet):
 
     return name
 
-
-def get_amazon_linux_image_id(client) -> Optional[str]:
-    """
-    Return a valid Amazon Linux AMI ID for specified region
-    """
-
-    result = client.describe_images(Owners=['amazon'], Filters=[
-        {'Name': 'name', 'Values': ['amzn*']},
-        {'Name': 'architecture', 'Values': ['x86_64']}])
-
-    if 'Images' not in result or not result['Images']:
-        return None
-
-    return result['Images'][0]['ImageId']
-
-
-def validate_instance_type(client, instance_type: str, subnet_id: str, *,
+def validate_instance_type(client, instance_type: str, image_id: str, subnet_id: str, *,
                            debug: bool = False) -> Optional[bool]:
-    image_id = get_amazon_linux_image_id(client)
-    if not image_id:
-        return None
-
     try:
         client.run_instances(
             ImageId=image_id,


### PR DESCRIPTION
Instead of looking for an amazon linux AMI use the AMI we already
have identified as the one we wish to use with the generated
cloud connector profile.