### PR TITLE
Fix 2 issues with how bootstrap calls puppet agent

### DIFF
--- a/tortuga_kits/awsadapter_7_0_3/files/aws-bootstrap-offline.tmpl
+++ b/tortuga_kits/awsadapter_7_0_3/files/aws-bootstrap-offline.tmpl
@@ -31,11 +31,11 @@ import json
 # port = {{ adminport }}
 # cfmUser = '{{ cfmuser }}'
 # cfmPassword = '{{ cfmpassword }}'
-# 
+#
 # override_dns_domain = {{ override_dns_domain }}
 # dns_options = '{{ dns_options }}'
 # dns_domain = '{{ dns_domain }}'
-# dns_nameservers = 
+# dns_nameservers =
 
 
 
@@ -138,8 +138,10 @@ def updateResolver(domainName):
 
 
 def bootstrapPuppet():
+    runCommand('touch /tmp/puppet_bootstrap.log')
     cmd = ('/opt/puppetlabs/bin/puppet agent'
            ' --logdest /tmp/puppet_bootstrap.log'
+           ' --no-daemonize'
            ' --onetime --server %s --waitforcert 120' % installerHostName)
 
     tryCommand(cmd, good_return_values=(0, 2), time_limit=10*60)

--- a/tortuga_kits/awsadapter_7_0_3/files/bootstrap.debian.tmpl
+++ b/tortuga_kits/awsadapter_7_0_3/files/bootstrap.debian.tmpl
@@ -140,8 +140,9 @@ def updateResolver(domainName):
 
 
 def bootstrapPuppet():
+    runCommand('touch /tmp/puppet_bootstrap.log')
     cmd = ('/opt/puppetlabs/bin/puppet agent --logdest /tmp/puppet_bootstrap.log'
-           ' --onetime --server %s --waitforcert 120' % installerHostName)
+           ' --no-daemonize --onetime --server %s --waitforcert 120' % installerHostName)
 
     tryCommand(cmd, good_return_values=(0, 2), time_limit=10 * 60)
 

--- a/tortuga_kits/awsadapter_7_0_3/files/bootstrap.python3.tmpl
+++ b/tortuga_kits/awsadapter_7_0_3/files/bootstrap.python3.tmpl
@@ -86,8 +86,10 @@ def installPuppet(ostype, vers):
 
 
 def bootstrapPuppet():
+    runCommand('touch /tmp/puppet_bootstrap.log')
     cmd = ('/opt/puppetlabs/bin/puppet agent'
            ' --logdest /tmp/puppet_bootstrap.log'
+           ' --no-daemonize'
            ' --onetime --server %s --waitforcert 120' % installerHostName)
 
     tryCommand(cmd, good_return_values=(0, 2), time_limit=10 * 60)

--- a/tortuga_kits/awsadapter_7_0_3/files/bootstrap.tmpl
+++ b/tortuga_kits/awsadapter_7_0_3/files/bootstrap.tmpl
@@ -140,8 +140,10 @@ def updateResolver(domainName):
 
 
 def bootstrapPuppet():
+    runCommand('touch /tmp/puppet_bootstrap.log')
     cmd = ('/opt/puppetlabs/bin/puppet agent'
            ' --logdest /tmp/puppet_bootstrap.log'
+           ' --no-daemonize'
            ' --onetime --server %s --waitforcert 120' % installerHostName)
 
     tryCommand(cmd, good_return_values=(0, 2), time_limit=10*60)

--- a/tortuga_kits/awsadapter_7_0_3/files/bootstrap.tmpl.reverse_dns
+++ b/tortuga_kits/awsadapter_7_0_3/files/bootstrap.tmpl.reverse_dns
@@ -138,8 +138,10 @@ def updateResolver(domainName):
 
 
 def bootstrapPuppet():
+    runCommand('touch /tmp/puppet_bootstrap.log')
     cmd = ('/opt/puppetlabs/bin/puppet agent'
            ' --logdest /tmp/puppet_bootstrap.log'
+           ' --no-daemonize'
            ' --onetime --server %s --waitforcert 120' % (installerHostName))
 
     runCommand(cmd)
@@ -147,9 +149,9 @@ def bootstrapPuppet():
 
 def main():
     subprocess.Popen('yum install -y bind-utils', shell=True).wait()
-    
+
     cmd = 'ip -4 a s eth0 | awk \'/inet/ { print $2}\' | sed \'s/\/.*//\''
-    
+
     p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     result = p.stdout.readline().rstrip()
     retval = p.wait()


### PR DESCRIPTION
1. By touching log file first, works around PUP-7331 that is
causing puppet agent to be run twice on every bootstrap script.
(The first run is a very short failure).
2. By using --no-daemonize, allows subprocess.wait to wait
on the correct child process. Without this the code advances
without blocking on puppet run.