### PR TITLE
[WIP] Tag EC2 instances at creation

### DIFF
--- a/src/tortuga/resourceAdapter/aws/aws.py
+++ b/src/tortuga/resourceAdapter/aws/aws.py
@@ -24,17 +24,22 @@ import sys
 import xml.etree.cElementTree as ET
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from typing import Any, Dict, List, NoReturn, Optional, Tuple
+from typing import Any, Dict, List, NoReturn, Optional, Tuple, Union
 from typing.io import TextIO
 
 import boto
 import boto.ec2
 import boto.vpc
+import boto3
+import botocore
 import gevent
 import gevent.queue
+from boto.ec2.blockdevicemapping import BlockDeviceMapping
 from boto.ec2.connection import EC2Connection
 from boto.ec2.networkinterface import (NetworkInterfaceCollection,
                                        NetworkInterfaceSpecification)
+from boto3.resources.base import ServiceResource
+from botocore.config import Config
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session
 from tortuga.addhost.addHostServerLocal import AddHostServerLocal
@@ -352,11 +357,12 @@ class Aws(ResourceAdapter):
         self.__runningOnEc2 = None
         self.__installer_ip: Optional[str] = None
 
-    def getEC2Connection(self, configDict: Dict[str, Any]) -> EC2Connection:
+    def _get_common_connection_args(self, configDict: Dict[str, Any]) \
+            -> Dict[str, Any]:
         """
-        :raises ConfigurationError: invalid AWS region specified
+        Constructs a dict of connection args common to both the boto and
+        boto3 connections
         """
-
         connectionArgs = {}
 
         # only include access/secret key if defined in adapter config
@@ -366,6 +372,14 @@ class Aws(ResourceAdapter):
 
             connectionArgs['aws_secret_access_key'] = \
                 configDict.get('awssecretkey')
+
+        return connectionArgs
+
+    def getEC2Connection(self, configDict: Dict[str, Any]) -> EC2Connection:
+        """
+        :raises ConfigurationError: invalid AWS region specified
+        """
+        connectionArgs = self._get_common_connection_args(configDict)
 
         if 'proxy_host' in configDict:
             self._logger.debug('Using proxy for AWS (%s:%s)' % (
@@ -385,6 +399,57 @@ class Aws(ResourceAdapter):
             configDict['region'],
             **connectionArgs,
         )
+
+        if ec2_conn is None:
+            raise ConfigurationError(
+                'Invalid AWS region [{}]'.format(configDict['region'])
+            )
+
+        return ec2_conn
+
+    def getEC2Connection3(self, configDict: Dict[str, Any]) -> ServiceResource:
+        """
+        Returns a boto3 connection to EC2
+
+        :raises ConfigurationError: invalid AWS region specified
+        """
+        connectionArgs = self._get_common_connection_args(configDict)
+
+        # For boto3, we put the proxy configuration in a
+        # botocore.config.Config instance
+        config = None
+        if 'proxy_host' in configDict:
+            self._logger.debug('Using proxy for AWS boto3 connection (%s:%s)' %
+                (configDict['proxy_host'], configDict['proxy_port']))
+
+            # Format proxy credentials, if applicable
+            proxy_url_template = '{user_pass}{host}:{port}'
+            user_pass = ''
+            if 'proxy_user' in configDict:
+                user_pass = configDict['proxy_user']
+
+                if 'proxy_pass' in configDict:
+                    user_pass += ':' + configDict['proxy_pass']
+
+                user_pass += '@'
+
+            proxy_url = proxy_url_template.format(
+                user_pass=user_pass,
+                host=configDict['proxy_host'],
+                port=configDict['proxy_port']
+            )
+
+            # boto assumes it's an HTTP proxy, so we'll do the same
+            # for boto3
+            proxy_dict = {'http': proxy_url}
+            config = Config(proxies=proxy_dict)
+
+        # Set up the session
+        session = boto3.Session(
+            region_name=configDict['region'],
+            **connectionArgs
+        )
+        ec2_conn = session.resource('ec2', config=config)
 
         if ec2_conn is None:
             raise ConfigurationError(
@@ -650,6 +715,9 @@ class Aws(ResourceAdapter):
             )
 
         launch_request.conn = self.getEC2Connection(launch_request.configDict)
+        launch_request.conn3 = self.getEC2Connection3(
+            launch_request.configDict
+        )
 
         if 'spot_instance_request' in addNodesRequest:
             # handle EC2 spot instance request
@@ -1273,8 +1341,8 @@ fqdn: %s
         self.__common_prelaunch(launch_request)
 
         try:
-            reservation = self.__launchEC2(
-                launch_request.conn, launch_request.configDict,
+            instances = self.__launchEC2(
+                launch_request.conn3, launch_request.configDict,
                 count=launch_request.addNodesRequest['count'],
                 addNodesRequest=launch_request.addNodesRequest,
             )
@@ -1286,7 +1354,7 @@ fqdn: %s
 
         launch_request.node_request_queue = \
             [dict(instance=instance, status='launched')
-             for instance in reservation.instances]
+             for instance in instances]
 
         # Wait for instances to reach 'running' state
         self.__wait_for_instances(dbSession, launch_request)
@@ -1301,7 +1369,7 @@ fqdn: %s
             NetworkNotFound
         """
 
-        conn = launch_request.conn
+        conn3 = launch_request.conn3
         configDict = launch_request.configDict
         addNodesRequest = launch_request.addNodesRequest
         dbHardwareProfile = launch_request.hardwareprofile
@@ -1340,11 +1408,11 @@ fqdn: %s
                 try:
                     node_request['instance'] = \
                         self.__launchEC2(
-                            conn,
+                            conn3,
                             configDict,
                             node=node_request['node'],
                             addNodesRequest=addNodesRequest
-                        ).instances[0]
+                        )[0]
 
                     node_request['status'] = 'launched'
 
@@ -1443,8 +1511,8 @@ fqdn: %s
 
     def __aws_check_instance_state(self, instance):
         try:
-            instance.update()
-        except boto.exception.EC2ResponseError as exc:
+            instance.reload()
+        except botocore.exceptions.ClientError as ex:
             # Not even the sample boto code appears to handle this
             # scenario. It appears there's a race condition between
             # creating an instance and polling for the instance
@@ -1455,12 +1523,12 @@ fqdn: %s
             # Subsequent update() calls are successful.
 
             self._logger.debug(
-                'Ignoring exception raised while'
-                ' updating instance: %s' % (str(exc)))
+                f'Ignoring exception raised while updating instance: {ex}'
+            )
 
             return None
 
-        return instance.state
+        return instance.state['Name']
 
     def process_item(self, launch_request: LaunchRequest, node_request: dict):
         """
@@ -1505,17 +1573,17 @@ fqdn: %s
                 raise AWSOperationTimeoutError(
                     'Timeout waiting for instance [{0}]'.format(instance.id))
 
-            if instance.state != 'pending':
+            if instance.state['Name'] != 'pending':
                 # Instance in unexpected state, report error
-                node_request['status'] = instance.state
+                node_request['status'] = instance.state['Name']
 
                 self._logger.error(
                     'Instance [%s] in unexpected state [%s]' % (
-                        instance.state))
+                        instance.state['Name']))
 
                 raise OperationFailed(
                     'Error launching instance: state=[{0}]'.format(
-                        instance.state))
+                        instance.state['Name']))
 
     def __failed_launch_cleanup_handler(self, session: Session,
                                         node_request: dict) -> None:
@@ -1882,8 +1950,11 @@ fqdn: %s
 
         return security_group
 
-    def _validate_ec2_launch_args(self, conn: EC2Connection,
+    def _validate_ec2_launch_args(self,
+                                  conn: Union[EC2Connection, ServiceResource],
                                   configDict: Dict[str, Any]):
+
+        # NOTE: the commented out portions are not boto3-compatible
         # # Get the kernel, if specified
         # if 'aki' in configDict and configDict['aki']:
         #     try:
@@ -1911,6 +1982,11 @@ fqdn: %s
         #                 configDict['ari'],
         #                 extErrMsg or '<no reason provided>'))
 
+        ConnException = boto.exception.EC2ResponseError
+        is_boto3_conn = isinstance(conn, ServiceResource)
+        if is_boto3_conn:
+            ConnException = botocore.exceptions.ClientError
+
         # Create placement group if needed.
         if configDict.get('placementgroup'):
             try:
@@ -1918,20 +1994,32 @@ fqdn: %s
                     'Attempting to create placement group [%s]' % (
                         configDict['placementgroup']))
 
-                conn.create_placement_group(configDict['placementgroup'])
+                if is_boto3_conn:
+                    conn.create_placement_group(
+                        GroupName=configDict['placementgroup'],
+                        Strategy='cluster'
+                    )
+                else:
+                    conn.create_placement_group(
+                        configDict['placementgroup'],
+                        strategy='cluster'
+                    )
 
                 self._logger.debug(
                     'Created placement group [%s]' % (
                         configDict['placementgroup']))
-            except boto.exception.EC2ResponseError as ex:
+            except ConnException as ex:
                 # let this fail, group may already exist
-
-                extErrMsg = self.__parseEC2ResponseError(ex)
+                if is_boto3_conn:
+                    extErrMsg = str(ex)
+                else:
+                    extErrMsg = self.__parseEC2ResponseError(ex)
 
                 self._logger.warning(
                     'Unable to create placement group [%s] (%s)' % (
                         configDict['placementgroup'],
                         extErrMsg or '<no reason provided>'))
+
 
     def __get_common_launch_args(
             self, conn: EC2Connection, configDict: Dict[str, Any],
@@ -2016,37 +2104,135 @@ fqdn: %s
 
         return args
 
-    def __launchEC2(self, conn: EC2Connection, configDict: Dict[str, Any],
+    def __get_common_launch_args3(
+            self, conn3: ServiceResource, configDict: Dict[str, Any],
+            node: Optional[Node] = None, *,
+            addNodesRequest: Optional[dict] = None) -> Dict[str, Any]:
+        """
+        Return key-value pairs of arguments for passing to launch API
+        """
+        args = {
+            'KeyName': configDict['keypair'],
+            'InstanceType': configDict['instancetype'],
+        }
+
+        # Set up placement dict
+        placement = {}
+        value = configDict.get('zone')
+        if value is not None:
+            placement['AvailabilityZone'] = value
+
+        value = configDict.get('placementgroup')
+        if value is not None:
+            placement['GroupName'] = value
+
+        # Add to args
+        if placement:
+            args['Placement'] = placement
+
+        # User data
+        if configDict['cloud_init']:
+            args['UserData'] = self.__get_user_data(configDict, node=node)
+
+        # Kernel ID
+        if 'aki' in configDict and configDict['aki']:
+            # Override kernel used for new instances
+            args['KernelId'] = configDict['aki']
+
+        # Ramdisk ID
+        if 'ari' in configDict and configDict['ari']:
+            # Override ramdisk used for new instances
+            args['RamdiskId'] = configDict['ari']
+
+        # Build 'BlockDeviceMappings'
+        bdms = self.__build_block_device_map(
+            conn3,
+            configDict['block_device_map']
+            if 'block_device_map' in configDict else None,
+            configDict['ami']
+        )
+        # bdms is a boto.ec2.blockdevicemapping.BlockDeviceMapping
+        # We need to translate it to a list of dicts for boto3
+        args['BlockDeviceMappings'] = \
+            translate_blockdevicemappings_for_boto3(bdms)
+
+        if 'ebs_optimized' in configDict:
+            args['EbsOptimized'] = configDict['ebs_optimized']
+
+        if 'monitoring_enabled' in configDict:
+            args['Monitoring'] = {'Enabled': configDict['monitoring_enabled']}
+
+        if 'iam_instance_profile_name' in configDict and \
+                configDict['iam_instance_profile_name']:
+            args['IamInstanceProfile'] = \
+                {'Name': configDict['iam_instance_profile_name']}
+
+        if 'subnet_id' in configDict and \
+                configDict['subnet_id'] is not None:
+            subnet_id = configDict['subnet_id']
+
+            # If "subnet_id" is defined, we know the instance belongs to a
+            # VPC. Handle the security group differently.
+            primary_nic = {
+                'AssociatePublicIpAddress': \
+                    configDict['associate_public_ip_address'],
+                'Groups': configDict.get('securitygroup', []),
+                'SubnetId': subnet_id,
+                'DeviceIndex': 0,  # AWS docs: primary NIC = device index of 0
+            }
+
+            # Handle private IP address
+            private_ip_address = get_private_ip_address_argument(
+                addNodesRequest
+            ) if addNodesRequest else None
+
+            if private_ip_address:
+                self._logger.debug(
+                    'Assigning ip address [%s] to new instance',
+                    private_ip_address
+                )
+                primary_nic['PrivateIpAddress'] = private_ip_address
+
+            args['NetworkInterfaces'] = [primary_nic]
+        else:
+            # Default instance (non-VPC)
+            args['SecurityGroupIds'] = configDict.get('securitygroup', [])
+
+        return args
+
+    def __launchEC2(self, conn3: ServiceResource, configDict: Dict[str, Any],
                     *, count: int = 1, node: Optional[Node] = None,
                     addNodesRequest: Optional[dict] = None):
         """
         Launch EC2 instances. If 'node' is specified, Tortuga node
         record exists at time of instance creation.
 
+        Note that conn3 is a boto3 connection to EC2.
+
         :raises CommandFailed:
         """
 
-        self._validate_ec2_launch_args(conn, configDict)
+        self._validate_ec2_launch_args(conn3, configDict)
 
-        runArgs = self.__get_common_launch_args(
-            conn,
+        runArgs = self.__get_common_launch_args3(
+            conn3,
             configDict,
             node=node,
             addNodesRequest=addNodesRequest
         )
 
         try:
-            return conn.run_instances(
-                configDict['ami'], max_count=count, **runArgs
+            return conn3.create_instances(
+                ImageId=configDict['ami'],
+                MinCount=1,
+                MaxCount=count,
+                **runArgs
             )
-        except boto.exception.EC2ResponseError as ex:
-            extErrMsg = self.__parseEC2ResponseError(ex)
+        except botocore.exceptions.ClientError as ex:
+            raise CommandFailed(f'AWS error: {ex}')
 
-            # Pass the exception message through for status message
-            # aesthetic purposes
-            raise CommandFailed('AWS error: %s' % (extErrMsg))
-
-    def __build_block_device_map(self, conn: EC2Connection,
+    def __build_block_device_map(self,
+                                 conn: Union[EC2Connection, ServiceResource],
                                  block_device_map, image_id: str):
         result = None
 
@@ -2058,10 +2244,17 @@ fqdn: %s
 
             result = block_device_map
 
-        ami = conn.get_image(image_id)
+        is_boto3_conn = isinstance(conn, ServiceResource)
+        if is_boto3_conn:
+            ami = conn.Image(image_id)
+            block_devices = \
+                [bdm['DeviceName'] for bdm in ami.block_device_mappings]
+        else:
+            ami = conn.get_image(image_id)
+            block_devices = list(ami.block_device_mapping)
 
         # determine root device name
-        root_block_devices = ec2_get_root_block_devices(ami)
+        root_block_devices = ec2_get_root_block_devices(block_devices)
 
         if root_block_devices:
             root_block_device = root_block_devices[0]
@@ -2525,3 +2718,47 @@ def get_private_ip_address_argument(addNodesRequest: Dict[str, Any]) \
         private_ip_address = None
 
     return private_ip_address
+
+
+def translate_blockdevicemappings_for_boto3(
+        block_device_mapping: BlockDeviceMapping) -> List[Dict]:
+    """
+    Translate block device mappings from
+    boto.ec2.blockdevicemapping.BlockDeviceMapping (effectively a dict of
+    boto.ec2.blockdevicemapping.BlockDeviceType objects) into a list
+    of dicts, where each dict describes a block device
+    """
+    ebs_attr_map = {
+        'snapshot_id': 'SnapshotId',
+        'delete_on_termination': 'DeleteOnTermination',
+        'volume_type': 'VolumeType',
+        'iops': 'Iops',
+        'encrypted': 'Encrypted',
+    }
+
+    block_device_list = []
+    for device_name, bdt in block_device_mapping.items():
+
+        # Root-level attributes
+        bd_dict = {'DeviceName': device_name}
+        no_device = getattr(bdt, 'no_device', False)
+        if no_device:
+            bd_dict['NoDevice'] = no_device
+
+        # Nested EBS attributes
+        ebs_dict = {}
+        for boto_attr, boto3_key in ebs_attr_map.items():
+            value = getattr(bdt, boto_attr)
+            if value is not None:
+                ebs_dict[boto3_key] = value
+        # Do this one manually for type conversion
+        if bdt.size is not None:
+            ebs_dict['VolumeSize'] = int(bdt.size)
+
+        if ebs_dict:
+            bd_dict['Ebs'] = ebs_dict
+
+        # Append to list of block devices
+        block_device_list.append(bd_dict)
+
+    return block_device_list

--- a/src/tortuga/resourceAdapter/aws/helpers.py
+++ b/src/tortuga/resourceAdapter/aws/helpers.py
@@ -16,9 +16,9 @@ import shlex
 from typing import Dict, Optional
 
 
-def ec2_get_root_block_devices(ami):
+def ec2_get_root_block_devices(block_devices):
     # Helper function for determining the root block device for an AMI
-    return [device for device in ami.block_device_mapping.keys()
+    return [device for device in block_devices
             if device in ('/dev/xvda', '/dev/sda', '/dev/sda1')]
 
 

--- a/src/tortuga/resourceAdapter/aws/launchRequest.py
+++ b/src/tortuga/resourceAdapter/aws/launchRequest.py
@@ -19,6 +19,7 @@ from tortuga.db.models.hardwareProfile import HardwareProfile
 from tortuga.db.models.node import Node
 from tortuga.db.models.softwareProfile import SoftwareProfile
 from boto.ec2.connection import EC2Connection
+from boto3.resources.base import ServiceResource
 
 
 class LaunchRequest(object):
@@ -30,6 +31,7 @@ class LaunchRequest(object):
         self.addNodesRequest: Optional[dict] = None
         self.configDict: Optional[Dict[str, Any]] = None
         self.conn: Optional[EC2Connection] = None
+        self.conn3: Optional[ServiceResource] = None
 
 
 def init_node_request_queue(nodes: List[Node]) -> List[Dict[str, Any]]:

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import mock
+import pytest
 
 import boto
-from moto import mock_ec2_deprecated
+from moto import mock_ec2, mock_ec2_deprecated
 from tortuga.db.hardwareProfilesDbHandler import HardwareProfilesDbHandler
 from tortuga.db.models.node import Node
 from tortuga.db.softwareProfilesDbHandler import SoftwareProfilesDbHandler
@@ -223,3 +224,325 @@ def test_start_update_node(load_config_dict_mock, pre_add_host_mock,
         fire_provisioned_event_mock.assert_called()
 
         pre_add_host_mock.assert_called()
+
+
+@pytest.mark.parametrize(
+    "proxy_host,proxy_port,proxy_user,proxy_pass",
+    [
+        (None, None, None, None),
+        ('proxy.com', 1234, None, None),
+        ('proxy.com', 1234, 'test.user', 'p4ssw0rd'),
+    ]
+)
+def test_boto3_conn_setup(proxy_host, proxy_port, proxy_user, proxy_pass):
+    """Test setup of boto3 connection"""
+
+    # Construct configDict
+    configDict = {
+        'awsaccesskey': 'the_key',
+        'awssecretkey': 'the_secret',
+        'region': 'us-east-1',
+    }
+    if proxy_host:
+        configDict['proxy_host'] = proxy_host
+        configDict['proxy_port'] = proxy_port
+        if proxy_user:
+            configDict['proxy_user'] = proxy_user
+            configDict['proxy_pass'] = proxy_pass
+
+    # Set up adapter and process configDict
+    adapter = Aws()
+    adapter.process_config(configDict)
+
+    # Get boto3 connection
+    session_cls = 'tortuga.resourceAdapter.aws.aws.boto3.Session'
+    config_cls = 'tortuga.resourceAdapter.aws.aws.Config'
+    with mock.patch(session_cls) as boto3_session_mock, \
+         mock.patch(config_cls) as botocore_config_mock:
+        conn3 = adapter.getEC2Connection3(configDict)
+
+    # Test session call args/kwargs
+    session_call_kwargs = boto3_session_mock.call_args[1]
+    assert len(session_call_kwargs) == 3
+    assert session_call_kwargs['aws_access_key_id'] == \
+        configDict['awsaccesskey']
+    assert session_call_kwargs['aws_secret_access_key'] == \
+        configDict['awssecretkey']
+    assert session_call_kwargs['region_name'] == configDict['region']
+
+    # Test config call args/kwargs if proxy used
+    if proxy_host is not None:
+        config_call_kwargs = botocore_config_mock.call_args[1]
+        proxy_dict = config_call_kwargs['proxies']
+        assert len(proxy_dict) == 1
+        assert 'http' in proxy_dict
+        proxy_url = f'{proxy_host}:{proxy_port}'
+        if proxy_user is not None:
+            proxy_url = f'{proxy_user}:{proxy_pass}@{proxy_url}'
+        assert proxy_dict['http'] == proxy_url
+
+
+def test_boto3_validate_launch_args():
+    """Test validation of launch args for boto3 connection"""
+    configDict = {
+        'awsaccesskey': 'the_key',
+        'awssecretkey': 'the_secret',
+        'region': 'us-east-1',
+        'placementgroup': 'testgroup',
+    }
+
+    # Set up adapter and process configDict
+    adapter = Aws()
+    adapter.process_config(configDict)
+
+    # Get boto3 connection
+    conn3 = adapter.getEC2Connection3(configDict)
+
+    # We have to mock this directly since moto doesn't implement
+    # a mock of create_placement_group at present (Oct. 2019)
+    with mock.patch.object(conn3, 'create_placement_group') as mock_cpg:
+        adapter._validate_ec2_launch_args(conn3, configDict)
+
+    # Check results
+    call_kwargs = mock_cpg.call_args[1]
+    assert len(call_kwargs) == 2
+    assert call_kwargs['GroupName'] == configDict['placementgroup']
+    assert call_kwargs['Strategy'] == 'cluster'
+
+
+@pytest.mark.parametrize(
+    "use_instance_hostname,name_tag,use_node,use_addNodesRequest",
+    [
+        (False, None, True, False),
+        (True, None, True, False),
+        (False, 'instance_name', True, False),
+        (True, 'instance_name', True, False),
+        (False, None, False, True),
+        (True, None, False, True),
+        (False, 'instance_name', False, True),
+        (True, 'instance_name', False, True),
+    ]
+)
+def test_get_instance_specific_tags(use_instance_hostname, name_tag, use_node,
+                                    use_addNodesRequest):
+    """Test tags generated for instance"""
+    # Set up configDict
+    configDict = {
+        'region': 'us-east-1',
+        'installer_ip': '127.0.0.1',
+        'tags': {'key1': 'value1', 'key2': 'value2'},
+        'use_instance_hostname': use_instance_hostname,
+    }
+    if name_tag:
+        configDict['tags']['Name'] = name_tag
+
+    # Set up node mock, if needed
+    node = None
+    if use_node:
+        node = mock.Mock(spec=Node)
+        node.name = 'node_name'
+        node.hardwareprofile.name = 'node_hwp'
+        node.softwareprofile.name = 'node_swp'
+
+    # Set up addNodesRequest, if needed
+    addNodesRequest = {}
+    if use_addNodesRequest:
+        addNodesRequest = {'softwareProfile': 'swp', 'hardwareProfile': 'hwp'}
+
+    # Set up adapter - no need to process configDict since the tags
+    # are already in processed form
+    adapter = Aws()
+
+    # Get boto3 connection
+    conn3 = adapter.getEC2Connection3(configDict)
+
+    # Get tags
+    tags = adapter._Aws__get_instance_specific_tags(
+        configDict, node=node, addNodesRequest=addNodesRequest
+    )
+
+    # Manually generate expected contents
+    expected_hwp_name = node.hardwareprofile.name if use_node \
+        else addNodesRequest['hardwareProfile']
+    expected_swp_name = node.softwareprofile.name if use_node \
+        else addNodesRequest['softwareProfile']
+    expected_name = configDict.get('tags').get('Name', None)
+    if use_instance_hostname:
+        if expected_name is None:
+            expected_name = 'Tortuga compute node'
+    elif node:
+        expected_name = node.name
+    expected_num_tags = 4 + int(expected_name is not None) + \
+        (len(configDict['tags']) - int(bool(name_tag)))
+
+    # Check results
+    assert len(tags) == expected_num_tags
+    assert tags['tortuga:installer_ipaddress'] == configDict['installer_ip']
+    assert tags['tortuga:installer_hostname'] == \
+        adapter.installer_public_hostname
+    assert tags['tortuga:softwareprofile'] == expected_swp_name
+    assert tags['tortuga:hardwareprofile'] == expected_hwp_name
+    for k,v in configDict['tags'].items():
+        # 'Name' tag will not *always* match - we check it below
+        if k != 'Name':
+            assert tags[k] == v
+    if expected_name is None:
+        assert 'Name' not in tags
+    else:
+        assert tags['Name'] == expected_name
+
+
+@pytest.mark.parametrize("subnet_id", ['fake_subnet_id', None])
+def test_get_common_launch_args3(subnet_id, valid_ami):
+    """Test construction of launch args dict for run_instances with boto3"""
+    # Set up configDict
+    configDict = {
+        'keypair': 'keypair_name',
+        'instancetype': 't2.large',
+        'region': 'us-east-1',
+        'zone': 'fake_zone',
+        'installer_ip': '127.0.0.1',
+        'use_instance_hostname': False,
+        'placementgroup': 'fake_placementgroup',
+        'cloud_init': None,
+        'ami': valid_ami,
+        'aki': 'fake_kernel_id',
+        'ari': 'fake_ramdisk_id',
+        'ebs_optimized': True,
+        'monitoring_enabled': False,
+        'iam_instance_profile_name': 'fake_profile_name',
+        'subnet_id': subnet_id,
+        'securitygroup': ['sg-1234'],
+        'associate_public_ip_address': True,
+        'use_tags': True,
+        'tags': {'key1': 'value1', 'key2': 'value2'},
+    }
+
+    # Set up adapter and process configDict
+    adapter = Aws()
+    #adapter.process_config(configDict)
+
+    # Get boto3 connection
+    conn3 = adapter.getEC2Connection3(configDict)
+
+    # Set up a mock node
+    node = mock.Mock(spec=Node)
+    node.hardwareprofile.name = 'hwp_name'
+    node.softwareprofile.name = 'swp_name'
+    node.name = 'node_name'
+
+    # Execute function
+    with mock_ec2():
+        run_args = adapter._Aws__get_common_launch_args3(conn3, configDict,
+                                                         node=node)
+
+    # Check results
+    assert run_args['EbsOptimized'] == configDict['ebs_optimized']
+    assert run_args['IamInstanceProfile']['Name'] == \
+        configDict['iam_instance_profile_name']
+    assert run_args['InstanceType'] == configDict['instancetype']
+    assert run_args['KernelId'] == configDict['aki']
+    assert run_args['KeyName'] == configDict['keypair']
+    assert run_args['Monitoring']['Enabled'] == \
+        configDict['monitoring_enabled']
+    assert run_args['Placement']['AvailabilityZone'] == configDict['zone']
+    assert run_args['Placement']['GroupName'] == configDict['placementgroup']
+    assert run_args['RamdiskId'] == configDict['ari']
+
+    # Depends on subnet id
+    if subnet_id is not None:
+        assert 'NetworkInterfaces' in run_args
+        assert len(run_args['NetworkInterfaces']) == 1
+        ni = run_args['NetworkInterfaces'][0]
+        assert ni['AssociatePublicIpAddress'] == \
+            configDict['associate_public_ip_address']
+        assert ni['Groups'] == configDict['securitygroup']
+        assert ni['SubnetId'] == configDict['subnet_id']
+    else:
+        assert 'SecurityGroupIds' in run_args
+        assert run_args['SecurityGroupIds'] == configDict['securitygroup']
+
+    # Don't need to check instance tags here, since it's done in another test
+    tag_specs = \
+        {d['ResourceType']: d['Tags'] for d in run_args['TagSpecifications']}
+    volume_tag_specs = {d['Key']: d['Value'] for d in tag_specs['volume']}
+    assert len(volume_tag_specs) == len(configDict['tags'])
+    for k in volume_tag_specs:
+        assert volume_tag_specs[k] == configDict['tags'][k]
+
+
+def test_launch_EC2(valid_ami):
+    """Test full EC2 launch process"""
+    # Set up configDict
+    configDict = {
+        'keypair': 'keypair_name',
+        'instancetype': 't2.large',
+        'region': 'us-east-1',
+        'awsaccesskey': 'the_key',
+        'awssecretkey': 'the_secret',
+        'zone': 'fake_zone',
+        'use_instance_hostname': False,
+        'ami': valid_ami,
+        'aki': 'fake_kernel_id',
+        'ari': 'fake_ramdisk_id',
+        'ebs_optimized': True,
+        'monitoring_enabled': False,
+        'iam_instance_profile_name': 'fake_profile_name',
+        'subnet_id': None,
+        'securitygroup': ['sg-1234'],
+        'associate_public_ip_address': True,
+        'tags': 'key1=value1 key2=value2',
+    }
+
+    # Set up adapter and process configDict
+    adapter = Aws()
+    adapter.process_config(configDict)
+
+    # Set up a mock node
+    node = mock.Mock(spec=Node)
+    node.hardwareprofile.name = 'hwp_name'
+    node.softwareprofile.name = 'swp_name'
+    node.name = 'node_name'
+
+    # Run __launchEC2
+    with mock_ec2():
+        # Get boto3 connection
+        conn3 = adapter.getEC2Connection3(configDict)
+
+        # Create mock vpc and subnet
+        vpc = conn3.create_vpc(CidrBlock='10.0.0.0/16')
+        subnet = conn3.create_subnet(CidrBlock='10.0.0.0/18', VpcId=vpc.id)
+        configDict['subnet_id'] = subnet.id
+
+        # Launch instances
+        result = adapter._Aws__launchEC2(conn3, configDict, count=1, node=node)
+
+    # Check results
+    assert len(result) == 1
+    instance = result[0]
+    assert instance.image.id == configDict['ami']
+    assert instance.key_pair.key_name == configDict['keypair']
+    assert instance.instance_type == configDict['instancetype']
+    assert instance.vpc_id == vpc.id
+    assert instance.subnet_id == subnet.id
+    assert len(instance.network_interfaces) == 1
+    assert instance.network_interfaces[0].groups[0]['GroupName'] == \
+        configDict['securitygroup'][0]
+    # NOTE: moto does not give the correct result for these two. I have tested
+    # manually on AWS and confirmed that they work as expected.
+    #assert instance.ebs_optimized == configDict['ebs_optimized']
+    #assert instance.monitoring['state'] == 'disabled'
+
+    # Check tags
+    instance_tags = {d['Key']: d['Value'] for d in instance.tags}
+    assert instance_tags['Name'] == node.name
+    assert instance_tags['key1'] == 'value1'
+    assert instance_tags['key2'] == 'value2'
+    assert instance_tags['tortuga:softwareprofile'] == \
+        node.softwareprofile.name
+    assert instance_tags['tortuga:hardwareprofile'] == \
+        node.hardwareprofile.name
+    assert instance_tags['tortuga:installer_ipaddress'] == \
+        adapter.installer_public_ipaddress
+    assert instance_tags['tortuga:installer_hostname'] == \
+        adapter.installer_public_hostname

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -89,7 +89,7 @@ def test_deleteNode(load_config_dict_mock, dbm):
 @mock.patch.object(Aws, 'fire_provisioned_event')
 @mock.patch.object(Aws, '_pre_add_host')
 @mock.patch.object(Aws, '_load_config_from_database')
-@mock_ec2_deprecated
+@mock_ec2
 def test_start(load_config_dict_mock, pre_add_host_mock,
                fire_provisioned_even_mock, get_instance_size_mapping_mock,
                dbm, valid_ami):
@@ -482,6 +482,7 @@ def test_launch_EC2(valid_ami):
         'awssecretkey': 'the_secret',
         'zone': 'fake_zone',
         'use_instance_hostname': False,
+        'block_device_map': '/dev/sda1=:30:true:io1:500:encrypted',
         'ami': valid_ami,
         'aki': 'fake_kernel_id',
         'ari': 'fake_ramdisk_id',


### PR DESCRIPTION
This PR adds the ability to tag EC2 instances and their associated volumes at creation time.  It requires converting the calls to the EC2 API to use `boto3`, as well as adding some functionality to build up the metadata for those calls, since the format differs fairly significantly from the same calls using `boto`.  This PR builds on the information in #184.

I also looked into whether this could also be applied to spot instances, although it sounds like that is not a requirement at present, based on discussions with @tpdownes.  However, it does not appear to be possible to "tag at creation" for spot instance requests or spot instances themselves (see AWS docs [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-ec2-resources-table) and [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html#concepts-spot-instances-request-tags)).  This could possibly be handled by using launch templates or by adding functionality for managing spot fleets, but those are separate (and probably much more extensive) projects.

# Overview of changes
* Define a new method for instantiating a `boto3` connection to EC2 (`getEC2Connection3`)
* Attach this connection to the `LaunchRequest` object associated with the adapter
* Rework `__launchEC2` to use the new connection:
  * Use the `boto3` connection's `create_instances` method to create the instances
  * Define a new method for setting up the args for `create_instances` (`__get_common_launch_args3`). This could possibly be reworked so that the original `__get_common_launch_args` can handle both connection types, but I'm not sure if it's worth the effort.  Let me know if you prefer that I do so.
* Remove tag application from `__post_launch_action`; add new functionality to `__get_common_launch_args3` for adding the tags to the arguments which will be passed to `create_instances`.

# Tests
* [x] Launch instances with tags and static `Name` tag
* [x] Launch instances with tags, using dynamic `Name` tag (set `use_instance_hostname=False` and set the `name-format` for the hardware profile)
* [x] Create IAM account with some kind of permission restriction on creating tags (post-instance-creation) and confirm that we can still add tags at creation
* [x] Confirmed that certain parameters which don't seem to be correctly handled by `moto` in the unit tests (`ebs_optimized`, `placementgroup`, `monitoring_enabled`) are properly handled in a real AWS environment
* [x] Tested custom block device mappings
* [x] Added a number of unit tests


# Other thoughts
* It looks like `boto` only allows the proxy connection to use HTTP.  `boto3` looks to be more flexible (see the [`proxies` argument](https://botocore.amazonaws.com/v1/documentation/api/1.12.122/reference/config.html#botocore.config.Config)) in terms of also allowing HTTPS proxies and only using the proxy for specific endpoints.  I'm not sure if that is potentially useful at all, but we could utilize this functionality by just adding a setting or two.  I have hard-coded HTTP for now - let me know if that does not seem reasonable.
* Related to proxies - the `botocore` documentation is not clear on how to specify a username or password for the proxy connection.  I've coded it up as `user:pass@hostname:port`.  If someone can confirm or deny that that is correct, that would be helpful.
* `__launchEC2` now returns a `boto3` `Instance` which is similar to that provided by `boto` but not exactly identical.  This instance gets added to the `node_request_queue` and then used in a few spots.  I don't see anywhere else that the resulting logic is used, so I **think** it's OK that I've reworked it to be compatible with the new object type only, and not retained compatibility with the old type.