### PR TITLE
Resolve several pip incompatibilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 Jinja2==2.10
-awscli==1.16.132
+awscli==1.16.275
 boto==2.49.0
-boto3==1.9.122
+boto3==1.10.11
 Click==7.0
-colorama==0.3.9
+colorama==0.4.1
 daemonize==2.4.7
 gevent==1.3.7


### PR DESCRIPTION
The latest release of `azure-cli` requires `colorama~=0.4.1` which means accept versions `0.4.x`. The version of the `awscli` presently in use by the kit requires `colorama>=0.2.5,<=0.3.9`.

This also resolves a problem where PyYAML 5.1.2 is installed but the older version of `awscli` needs a much older version of `pyyaml`. The new `awscli` doesn't need `pyyaml` at all.

I think we should consider removing `colorama` from this file as it is an indirect dependency. I realize there are benefits to `pip freeze` for re-creating an exact known working virtual environment but that's a separate question from actually stating them as requirements for installation. I think we should consider two separate files for these purposes.