### PR TITLE
Fix unit tests

### DIFF
--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -154,6 +154,7 @@ def test_start_update_node(load_config_dict_mock, pre_add_host_mock,
         'awssecretkey': 'the_secret',
         'ami': valid_ami,
         'use_instance_hostname': 'true',
+        'instancetype': 'm5.large',
     }
 
     load_config_dict_mock.return_value = configDict

--- a/tests/test_aws_config.py
+++ b/tests/test_aws_config.py
@@ -38,7 +38,7 @@ def test_invalid_adapter_configuration(dbm):
                 adapter = Aws()
                 adapter.session = session
 
-                adapter.getResourceAdapterConfig()
+                adapter.get_config()
 
 
 def test_minimal_config(dbm, minimal_configDict):
@@ -49,7 +49,7 @@ def test_minimal_config(dbm, minimal_configDict):
             adapter = Aws()
             adapter.session = session
 
-            config = adapter.getResourceAdapterConfig()
+            config = adapter.get_config()
 
             assert 'ami' in config
 
@@ -73,7 +73,7 @@ def test_override_dns_domain_enabled(dbm):
             adapter = Aws()
             adapter.session = session
 
-            config = adapter.getResourceAdapterConfig()
+            config = adapter.get_config()
 
             assert isinstance(config['override_dns_domain'], bool)
 
@@ -100,7 +100,7 @@ def test_override_dns_domain_enabled_with_dns_domain(dbm):
             adapter = Aws()
             adapter.session = session
 
-            config = adapter.getResourceAdapterConfig()
+            config = adapter.get_config()
 
             assert isinstance(config['override_dns_domain'], bool)
 
@@ -118,7 +118,7 @@ def test_missing_ami_setting(load_config_dict_mock, dbm):
             adapter = Aws()
             adapter.session = session
 
-            adapter.getResourceAdapterConfig()
+            adapter.get_config()
 
 
 @mock.patch.object(Aws, '_load_config_from_database')
@@ -134,7 +134,7 @@ def test_use_instance_hostname(load_config_dict_mock, dbm):
         adapter = Aws()
         adapter.session = session
 
-        result = adapter.getResourceAdapterConfig()
+        result = adapter.get_config()
 
         assert result['dns_domain'] == 'cloud.example.com'
 
@@ -149,7 +149,7 @@ def test_defaults(load_config_dict_mock, dbm):
         adapter = Aws()
         adapter.session = session
 
-        result = adapter.getResourceAdapterConfig()
+        result = adapter.get_config()
 
         assert result['ami'] == 'ami-XXXXXXXX'
 
@@ -179,4 +179,4 @@ def test_invalid_settings(load_config_dict_mock, dbm):
             adapter = Aws()
             adapter.session = session
 
-            adapter.getResourceAdapterConfig()
+            adapter.get_config()

--- a/tests/test_user_data.py
+++ b/tests/test_user_data.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
 
     adapter = Aws()
 
-    config = adapter.getResourceAdapterConfig()
+    config = adapter.get_config()
 
     result = adapter._Aws__get_user_data_script(fp, config)
 
@@ -105,7 +105,7 @@ if __name__ == '__main__':
 
     adapter = Aws()
 
-    config = adapter.getResourceAdapterConfig()
+    config = adapter.get_config()
 
     class DummyNode:
         def __init__(self, name):
@@ -146,7 +146,7 @@ if __name__ == '__main__':
 
     adapter = Aws()
 
-    config = adapter.getResourceAdapterConfig()
+    config = adapter.get_config()
 
     result = adapter.expand_cloud_init_user_data_template(
         config, template=Template(tmpl))


### PR DESCRIPTION
Fix several unit tests that were broken in master:

* `tests/test_aws.py::test_start_update_node` needed an `instancetype` added to the `configDict`
* Several tests in `tests/test_aws_config.py` were using the old syntax for getting the resource adapter configuration, `getResourceAdapterConfig`, which has been updated to `get_config`.