### PR TITLE
Implement helper for fixing managed tags

### DIFF
--- a/kit.json
+++ b/kit.json
@@ -3,5 +3,5 @@
   "version": "7.1.0",
   "iteration": "0",
   "description": "AWS resource adapter",
-  "requires_core": "7.1.0+002"
+  "requires_core": "7.1.0+003"
 }

--- a/src/tortuga/resourceAdapter/aws/aws.py
+++ b/src/tortuga/resourceAdapter/aws/aws.py
@@ -65,6 +65,7 @@ from tortuga.exceptions.resourceNotFound import ResourceNotFound
 from tortuga.node import state
 from tortuga.resourceAdapter.resourceAdapter import (DEFAULT_CONFIGURATION_PROFILE_NAME,
                                                      ResourceAdapter)
+from tortuga.resourceAdapter.utility import patch_managed_tags
 
 from .exceptions import AWSOperationTimeoutError
 from .helpers import (_get_encoded_list, _quote_str,
@@ -572,6 +573,7 @@ class Aws(ResourceAdapter):
         name_tag = self._get_name_tag(configDict)
         if name_tag:
             tag_dict['Name'] = name_tag
+        tags = patch_managed_tags(tags)
 
         # Convert to a list of boto.ec2.autoscale.tag.Tag objects
         # Set "propagate-at-launch" to be always True so that instances in
@@ -2307,6 +2309,7 @@ fqdn: %s
         name_tag = self._get_name_tag(configDict, node)
         if name_tag is not None:
             tags['Name'] = name_tag
+        tags = patch_managed_tags(tags)
 
         return tags
 
@@ -2341,6 +2344,7 @@ fqdn: %s
         name_tag = self._get_name_tag(config, node)
         if name_tag:
             tags['Name'] = name_tag
+        tags = patch_managed_tags(tags)
 
         self._tag_resources(conn, [instance.id], tags)
         self._tag_ebs_volumes(conn, instance, tags)


### PR DESCRIPTION
Add a helper function for trimming `managed:` from tag keys/names before the tags are added to a cloud instance.  The prefix is maintained in the node-tag record in the Tortuga database as a way of internally tracking managed tags.

The helper function was implemented in three places:
* Tag compilation before launching EC2 instances with tags attached
* Tag compilation before creating auto-scaling groups with tags attached
* `_tag_instance` method which is used to tag instances and EBS volumes post-launch

I've tested this in AWS by creating a cloud server using `navopsctl create task task.yaml` with the following content:
```
metadata:
  apiVersion: v1
  type: Task
spec:
  childTaskIds: null
  init:
    clusterProfileId: 985459ca-3b0b-42fb-88a0-d8b588cc624b
    count: 1
    tags:
    - name: mytag
      value: runnow
  type: create-ClusterServers
```
Without this patch, the instance gets a `managed:mytag` tag applied with value `runnow` (as seen in the AWS console); post-patch, the instance gets a `mytag` tag applied with value `runnow`.