### PR TITLE
Fix spot instance tagging

### DIFF
--- a/src/tortuga/resourceAdapter/aws/aws.py
+++ b/src/tortuga/resourceAdapter/aws/aws.py
@@ -932,8 +932,9 @@ class Aws(ResourceAdapter):
                     dnsdomain = configDict.get('dns_domain', None)
 
                 insertnode_request = {
-                   'softwareProfile': dbSoftwareProfile.name,
-                   'hardwareProfile': dbHardwareProfile.name,
+                    'softwareProfile': dbSoftwareProfile.name,
+                    'hardwareProfile': dbHardwareProfile.name,
+                    'resource_adapter_configuration': cfgname,
                 }
                 args = self.__get_request_spot_instance_args(
                     conn,


### PR DESCRIPTION
Store resource adapter configuration in insert node request so that the node can ping the Tortuga API and tell it which resource adapter profile it is using, instead of falling back to the default profile.