### PR TITLE
Support new AWS regions

### DIFF
--- a/src/tortuga/resourceAdapter/aws/settings.py
+++ b/src/tortuga/resourceAdapter/aws/settings.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import boto.ec2
+from boto3.session import Session
 
 from tortuga.resourceAdapterConfiguration import settings
 
@@ -109,7 +109,7 @@ SETTINGS = {
         display_name='Region',
         description='AWS region',
         default='us-east-1',
-        values=[region.name for region in boto.ec2.regions()],
+        values=[region for region in Session().get_available_regions('ec2')],
         **GROUP_INSTANCES
     ),
     'zone': settings.StringSetting(
@@ -338,3 +338,4 @@ SETTINGS = {
         advanced=True
     ),
 }
+

--- a/tortuga_kits/awsadapter/puppet_modules/univa-tortuga_kit_awsadapter/manifests/management.pp
+++ b/tortuga_kits/awsadapter/puppet_modules/univa-tortuga_kit_awsadapter/manifests/management.pp
@@ -1,4 +1,4 @@
-# Copyright 2008-2018 Univa Corporation
+# Copyright 2008-2019 Univa Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,15 @@ class tortuga_kit_awsadapter::management::package {
   include tortuga::config
 
   ensure_resource('package', 'unzip', {'ensure' => 'installed'})
+
+  # Update boto config to support new regions
+  ini_setting { "region endpoint heuristics":
+    ensure  => present,
+    path    => '/etc/boto.cfg',
+    section => 'Boto',
+    setting => 'use_endpoint_heuristics',
+    value   => 'True',
+  }
 
   if $::osfamily == 'RedHat' {
     if versioncmp($facts['os']['release']['major'], '7') < 0 {

--- a/tortuga_kits/awsadapter/puppet_modules/univa-tortuga_kit_awsadapter/metadata.json
+++ b/tortuga_kits/awsadapter/puppet_modules/univa-tortuga_kit_awsadapter/metadata.json
@@ -8,6 +8,7 @@
   "project_page": "http://univa.com",
   "issues_url": "https://support.univa.com",
   "dependencies": [
-    {"name":"puppetlabs/stdlib"}
+    {"name":"puppetlabs/stdlib"},
+    {"name":"puppetlabs-inifile"}
   ]
 }


### PR DESCRIPTION
Changes to use boto3 for getting fixed region lists and using
auto detection for new regions boto2 doesn't know about.