### PR TITLE
Adding requested tags to spot instances

### DIFF
--- a/src/tortuga/resourceAdapter/aws/aws.py
+++ b/src/tortuga/resourceAdapter/aws/aws.py
@@ -936,6 +936,14 @@ class Aws(ResourceAdapter):
                     'hardwareProfile': dbHardwareProfile.name,
                     'resource_adapter_configuration': cfgname,
                 }
+
+                # Add any tags from the addNodesRequest (i.e., that aren't
+                # directly attached to the adapter profile configuration)
+                # so they can be applied once the spot instance comes online
+                requested_tags = addNodesRequest.get('tags', {})
+                if requested_tags:
+                    insertnode_request['tags'] = requested_tags
+
                 args = self.__get_request_spot_instance_args(
                     conn,
                     addNodesRequest,


### PR DESCRIPTION
This commit adds tags included in the `addNodesRequest` to the `insertnode_request` saved in the userdata bootstrap script. When the spot instance boots up and pings the tortuga API, this allows it to tell tortuga about additional tags which should be applied to it that aren't part of the adapter configuration profile.

Getting the tags out of the request data and applying them to the instance is already part of the available functionality in tortuga (see [here](https://github.com/UnivaCorporation/tortuga/blob/master/src/installer/src/tortuga/resourceAdapter/resourceAdapter.py#L131) and [here](https://github.com/UnivaCorporation/tortuga/blob/master/src/installer/src/tortuga/resourceAdapter/resourceAdapter.py#L442)).

I've tested this in AWS and all of the requested tags are applied as expected.  Example:

Spot instance booting up:
![image](https://user-images.githubusercontent.com/10966130/71682166-70ba9400-2d54-11ea-8c6c-0a15f883e99a.png)

Resulting tags (shown in AWS console):
![image](https://user-images.githubusercontent.com/10966130/71682179-7c0dbf80-2d54-11ea-8d25-4b62eb47d1ef.png)