### PR TITLE
Spot instance tags fixes

### DIFF
--- a/kit.json
+++ b/kit.json
@@ -3,5 +3,5 @@
   "version": "7.1.0",
   "iteration": "0",
   "description": "AWS resource adapter",
-  "requires_core": "7.1.0+003"
+  "requires_core": "7.1.0+004"
 }

--- a/src/tortuga/resourceAdapter/aws/aws.py
+++ b/src/tortuga/resourceAdapter/aws/aws.py
@@ -1013,8 +1013,19 @@ class Aws(ResourceAdapter):
                 session = self.session
 
                 for node in nodes:
-                    # Add the node name to the insertnode_request and encrypt
-                    insertnode_request['node_name'] = node.name
+                    # Add the node name to the insertnode_request and
+                    # instructions to skip a step in the validation (usually
+                    # an error is thrown if the hardware profile doesn't allow
+                    # the node name to be set, but a name is included in the
+                    # addNodesRequest)
+                    insertnode_request.update(
+                        {
+                            'node_name': node.name,
+                            'skip_hostname_hwprofile_validation': True,
+                        }
+                    )
+
+                    # Encrypt
                     encrypted_insertnode_request = encrypt_insertnode_request(
                         self._cm.get_encryption_key(), insertnode_request
                     )

--- a/src/tortuga/resourceAdapter/aws/aws.py
+++ b/src/tortuga/resourceAdapter/aws/aws.py
@@ -2347,7 +2347,7 @@ fqdn: %s
         return name_tag
 
     def _tag_instance(self, config: dict, conn: EC2Connection,
-                      node: Node, instance):
+                      node: Node, instance, tags: Dict[str, str] = {}):
         """
         Add tags to a VM instance and attached EBS volumes
 
@@ -2355,13 +2355,17 @@ fqdn: %s
         :param EC2Connection conn: a configured EC2 connection
         :param Node node:          the database node instance
         :param instance:           the EC2 instance to tag
+        :param tags:               optional dict of tags to apply; if not
+                                   provided, default tags are used
 
         """
         self._logger.debug(
             'Assigning tags to instance: {}'.format(instance.id))
 
-        tags = self.get_initial_tags(config, node.hardwareprofile.name,
-                                     node.softwareprofile.name, node=node)
+        # If a dict of tags is not provided, get default tags
+        if not tags:
+            tags = self.get_initial_tags(config, node.hardwareprofile.name,
+                                         node.softwareprofile.name, node=node)
 
         self._tag_resources(conn, [instance.id], tags)
         self._tag_ebs_volumes(conn, instance, tags)

--- a/src/tortuga/resourceAdapter/aws/aws.py
+++ b/src/tortuga/resourceAdapter/aws/aws.py
@@ -837,6 +837,10 @@ class Aws(ResourceAdapter):
                 launch_request.addNodesRequest.get('resource_adapter_configuration'))
         )
 
+        # Try to set public hostname
+        if instance.public_dns_name:
+            node.public_hostname = instance.public_dns_name
+
         # attempt to find matching spot instance request
         if 'spot_instance_request_id' in nodedetail['metadata']:
             sir_id = nodedetail['metadata']['spot_instance_request_id']


### PR DESCRIPTION
# Description
This PR changes how spot instances are handled when a custom hostname is used (i.e., `use_instance_hostname == False`).  The new workflow is:

1. Create a node entry and tag entries
2. Generate an `insertnode_request` for the userdata provided to the spot instance, which means this instance type now will self-register with Tortuga.  The data includes the name of the node so that Tortuga can look up the existing node entry when the instance boots up and registers itself.
3. When the spot instance registers, look up the existing node entry and add some information to it from the AWS instance metadata.  Also look up the existing tag entries and apply them to the instance.

This requires a corresponding update in tortuga core: https://github.com/UnivaCorporation/tortuga/pull/599

# Testing
In a live AWS environment, I've tested that the following workflows function as expected:

- [x] standard instance with `use_instance_hostname == True`
- [x] standard instance with `use_instance_hostname == False`
- [x] spot instance with `use_instance_hostname == True`
- [x] spot instance with `use_instance_hostname == False`
- [ ] standard instance in a scaleset with `use_instance_hostname == True`
- [ ] standard instance in a scaleset with `use_instance_hostname == False`
- [ ] spot instance in a scaleset with `use_instance_hostname == True`
- [ ] spot instance in a scaleset with `use_instance_hostname == False`

Scaleset testing should be underway shortly.
