### PR TITLE
Modify pip requirements to flexibly align adapter with awscli and boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Jinja2==2.10
-awscli==1.16.275
+awscli~=1.18.0
 boto==2.49.0
-boto3==1.10.11
+boto3~=1.12.0
 Click==7.0
 colorama==0.4.1
 daemonize==2.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ awscli~=1.18.0
 boto==2.49.0
 boto3~=1.12.0
 Click==7.0
-colorama==0.4.1
+colorama~=0.4.1
 daemonize==2.4.7
 gevent==1.3.7


### PR DESCRIPTION
Also include an update to contemporary releases that drop support for Python 2.6 and 3.3 (`awscli==1.16.x` appears to be dead as of January 2020). Here are the dependencies of the relevant packages as of March 2020:

```
╰─>$ grep "Requires.*boto" awscli-1.18.28.dist-info/METADATA boto-2.49.0.dist-info/METADATA boto3-1.12.28.dist-info/METADATA                                (base)
awscli-1.18.28.dist-info/METADATA:Requires-Dist: botocore (==1.15.28)
boto3-1.12.28.dist-info/METADATA:Requires-Dist: botocore (<1.16.0,>=1.15.28)
```

If you mentally subtract `0.2` from the version numbers above, these dependencies will help you understand why the following is happening:

```
Requirement already satisfied: greenlet>=0.4.14; platform_python_implementation == "CPython" in /opt/tortuga/lib/python3.6/site-packages (from gevent==1.3.7->tortuga-aws-adapter->-r /opt/tortuga/kits/kit-awsadapter-7.1.0-71024/tortuga_kits/awsadapter_7_1_0/requirements.txt (line 1)) (0.4.15)
Collecting botocore<1.14.0,>=1.13.11
Downloading botocore-1.13.50-py2.py3-none-any.whl (5.9 MB)
...
ERROR: awscli 1.16.275 has requirement botocore==1.13.11, but you'll have botocore 1.13.50 which is incompatible.
```

That is to say, `boto3` will accept versions of `botocore` that are the same **or above** the version being required by `awscli`. `pip` resolves this by installing the highest allowed version. The solution is to stop fixing on a specific release of `awscli` and to allow it to float upward in alignment with `boto3` and `botocore`. New releases of these libraries come out every day (more or less). Picking one at random and fixing it is not a clearly safer/easier choice compared to fixing on a specific minor release series.

Additionally directly align version requirements for `colorama` with the `azure-cli` package:
```
azure-cli 2.0.76 has requirement colorama~=0.4.1, but you'll have colorama 0.3.9 which is incompatible.
```