### PR TITLE
Resolve issues with scale set deletion workflow

### DIFF
--- a/tortuga_kits/awsadapter/events/listeners/scalesets.py
+++ b/tortuga_kits/awsadapter/events/listeners/scalesets.py
@@ -14,6 +14,8 @@
 import logging
 from typing import Optional
 
+import botocore.exceptions
+
 from tortuga.events.listeners.base import BaseListener
 from tortuga.events.types import (ResourceRequestCreated,
                                   ResourceRequestUpdated,
@@ -229,6 +231,14 @@ class AwsScaleSetDeletedListener(AwsScaleSetListenerMixin, BaseListener):
                 resourceAdapterProfile=ssr.resourceadapter_profile_name,
                 adapter_args=ssr.adapter_arguments
             )
+        except botocore.exceptions.ClientError as ex:
+            # Check for "not found" exception by parsing response string. If
+            # found, the auto scaling group doesn't exist and there is no need
+            # to roll back the deletion request
+            response_msg = ex.response.get("Error", {}).get("Message", "")
+            if not "AutoScalingGroup name not found" in response_msg:
+                logger.exception("Error deleting resource request: %s", ex)
+                self._store.rollback(ssr)
         except Exception as ex:
-            logger.error("Error deleting resource request: %s", ex)
+            logger.exception("Error deleting resource request: %s", ex)
             self._store.rollback(ssr)

--- a/tortuga_kits/awsadapter/events/listeners/scalesets.py
+++ b/tortuga_kits/awsadapter/events/listeners/scalesets.py
@@ -233,8 +233,8 @@ class AwsScaleSetDeletedListener(AwsScaleSetListenerMixin, BaseListener):
             )
         except botocore.exceptions.ClientError as ex:
             # Check for "not found" exception by parsing response string. If
-            # found, the auto scaling group doesn't exist and there is no need
-            # to roll back the deletion request
+            # that is the case, the auto scaling group doesn't exist and there
+            # is no need to roll back the deletion request
             response_msg = ex.response.get("Error", {}).get("Message", "")
             if not "AutoScalingGroup name not found" in response_msg:
                 logger.exception("Error deleting resource request: %s", ex)


### PR DESCRIPTION
Fixes the issue where attempting to delete a scale set that doesn't exist prevents the corresponding resource request from being deleted. We now catch the exception and check whether it corresponds to an "AutoScalingGroup does not exist" error; and if so, continue on.