### PR TITLE
Record custom hostname in tag

### DIFF
--- a/src/tortuga/resourceAdapter/aws/aws.py
+++ b/src/tortuga/resourceAdapter/aws/aws.py
@@ -1740,6 +1740,12 @@ fqdn: %s
                 resource_adapter_configuration=resource_adapter_configuration,
             )
 
+        # Update 'tortuga-name' tag on the node if the instance hostname does not
+        # match what we have in tortuga
+        if instance.private_dns_name != node.name:
+            conn = self.getEC2Connection(launch_request.configDict)
+            self._tag_resources(conn, [instance.id], {'tortuga-name':node.name})
+
         # Commit node record changes (incl. host name and/or IP address)
         dbSession.commit()
 

--- a/src/tortuga/resourceAdapter/aws/aws.py
+++ b/src/tortuga/resourceAdapter/aws/aws.py
@@ -2420,8 +2420,14 @@ fqdn: %s
             tags = self.get_initial_tags(config, node.hardwareprofile.name,
                                          node.softwareprofile.name, node=node)
 
-        self._tag_resources(conn, [instance.id], tags)
         self._tag_ebs_volumes(conn, instance, tags)
+
+        # Update 'tortuga-name' tag on the node if the instance hostname does not
+        # match what we have in tortuga
+        if instance.private_dns_name != node.name:
+            tags['tortuga-name'] = node.name
+
+        self._tag_resources(conn, [instance.id], tags)
 
     def _tag_resources(self, conn: EC2Connection, resource_ids: List[str],
                        tags: Dict[str, str], replace: bool = False) -> None:

--- a/tortuga_kits/awsadapter/files/bootstrap.tmpl
+++ b/tortuga_kits/awsadapter/files/bootstrap.tmpl
@@ -49,12 +49,11 @@ def get_instance_data(path):
         raise Exception('Unable to read %s' % path)
     return response.read()
 
-def addNode():
+def addNode(local_hostname):
     tryCommand("mkdir -p /etc/pki/ca-trust/source/anchors/")
     tryCommand("curl http://%s:8008/ca.pem > /etc/pki/ca-trust/source/anchors/tortuga-ca.pem" % installerIpAddress)
     tryCommand("update-ca-trust")
     instance_id = get_instance_data('/instance-id')
-    local_hostname = get_instance_data('/local-hostname')
     local_ipv4 = get_instance_data('/local-ipv4')
     data = {
             'node_details': {
@@ -174,6 +173,7 @@ def bootstrapPuppet():
 
 
 def main():
+    fqdn = get_instance_data('/local-hostname')
     if override_dns_domain:
         with open('/etc/resolv.conf', 'w') as fp:
             fp.write('# Created by Tortuga\n')
@@ -192,7 +192,7 @@ def main():
             tryCommand('hostnamectl set-hostname --static %s' % (fqdn))
 
     if insertnode_request is not None:
-        addNode()
+        addNode(fqdn)
     tryCommand('setenforce permissive')
 
     # append /etc/hosts entry for installer


### PR DESCRIPTION
When the resource adapter detects that the hostname assigned
to a node doesn't match the hostname as known by AWS record the
custom hostname in the 'tortuga-name' tag.  This will allow
consumers of the AWS API to determine the instances hostname.