### PR TITLE
Enabling templating of insertnode_request

### DIFF
--- a/src/tortuga/resourceAdapter/aws/aws.py
+++ b/src/tortuga/resourceAdapter/aws/aws.py
@@ -1277,7 +1277,8 @@ insertnode_request = %s
 
         # process template file specified by 'cloud_init_script_template'
         # as YAML cloud-init configuration data
-        return self.expand_cloud_init_user_data_template(config, node=node)
+        return self.expand_cloud_init_user_data_template(config, node=node,
+            insertnode_request=insertnode_request)
 
     def __get_user_data_script(self, fp: TextIO,
                                config: Dict[str, str],

--- a/tortuga_kits/awsadapter/files/cloud-config-compute-redhat.yaml
+++ b/tortuga_kits/awsadapter/files/cloud-config-compute-redhat.yaml
@@ -1,3 +1,4 @@
+## template: jinja
 #cloud-config
 # vim: syntax=yaml
 
@@ -21,12 +22,44 @@ runcmd:
   - 'sed -i "s/SELINUX=enforcing/SELINUX=disabled/g" /etc/selinux/config'
   - 'cloud-init single --name users-groups --frequency always'
   - 'cloud-init single --name puppet --frequency always'
+  - curl -o /etc/pki/ca-trust/source/anchors/tortuga-ca.pem http://{{ installer }}:8008/ca.pem
+  - update-ca-trust
+  - systemctl daemon-reload
+  - systemctl start launch-register-node.service
 
 # example mount of a filesystem on attached block device
 #mounts:
 #  - [UUID=3cdb34c8-47f0-4e7e-b521-a75b9492e36b, /opt/R, auto, ro, '0', '0']
 
 write_files:
+{% if insertnode_request is defined %}
+  - path: /etc/launch_node_details
+    owner: root:root
+    permissions: '0644'
+    content: |
+      {
+          "node_details": {
+              "name": {{ '"{{ ds.meta_data.local_hostname }}"' }},
+              "metadata": {
+                  "ec2_instance_id": {{ '"{{ v1.instance_id }}"' }},
+                  "ec2_ipaddress": {{ '"{{ ds.meta_data.local_ipv4 }}"' }}
+              }
+          }
+      }
+  - path: /etc/systemd/system/launch-register-node.service
+    owner: root:root
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Register node with Navops Launch
+      [Service]
+      Type=simple
+      ExecStart=/bin/curl -X POST -H "Content-Type: application/json" \
+        -d @/etc/launch_node_details \
+        https://{{ installer }}:8443/v1/node-token/{{ insertnode_request }}
+      Restart=on-failure
+      RestartSec=30s
+{% endif %}
   - path: /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet5-release
     owner: root:root
     permissions: '0644'


### PR DESCRIPTION
1. cloud-init recipes do not presently have the ability to render the
insertnode_request variable which identifies the URI at which the
node must self-register upon boot. This is critical for instances
which are created "by AWS" rather than "by Launch" as in Spot and
Auto Scaling Groups.
2. In example cloud-init config file, demonstrate how SystemD can be
used to ensure that node self-registration is repeated until success.
This allows the Launch/Tortuga service to be down for short durations
while reducing the likelihood of orphaned Spot/ASG instances.