### PR TITLE
Do not enable Spot/ASG self-registration unless insertnode_request is defined

### DIFF
--- a/tortuga_kits/awsadapter/files/cloud-config-compute-redhat.yaml
+++ b/tortuga_kits/awsadapter/files/cloud-config-compute-redhat.yaml
@@ -24,8 +24,10 @@ runcmd:
   - 'cloud-init single --name puppet --frequency always'
   - curl -o /etc/pki/ca-trust/source/anchors/tortuga-ca.pem http://{{ installer }}:8008/ca.pem
   - update-ca-trust
+{% if insertnode_request is defined %}
   - systemctl daemon-reload
   - systemctl start launch-register-node.service
+{% endif %}
 
 # example mount of a filesystem on attached block device
 #mounts:


### PR DESCRIPTION
This is an update to the **example** cloud-init config file. It does not need to be backported to any release of the kit.

I also look at this example and see that Puppet is probably updating the trusted CAs in addition to the "manual" approach but I kinda like having the manual approach explicit if/when Puppet is not part of the picture. Hopefully harmless.