### PR TITLE
Add --fail to curl call on spot registration to ensure retries

### DIFF
--- a/tortuga_kits/awsadapter/files/cloud-config-compute-redhat.yaml
+++ b/tortuga_kits/awsadapter/files/cloud-config-compute-redhat.yaml
@@ -70,7 +70,7 @@ write_files:
       [Service]
       Type=simple
       RemainAfterExit=yes
-      ExecStart=/bin/curl -X POST -H "Content-Type: application/json" \
+      ExecStart=/bin/curl --fail -X POST -H "Content-Type: application/json" \
         -d @/etc/launch_node_details \
         https://{{ installer }}:8443/v1/node-token/{{ insertnode_request }}
       Restart=on-failure


### PR DESCRIPTION
Without `--fail` the cURL command will exit with code 0 even when non-20X HTTP status is returned. This ensures that HTTP failures are captured as non-0 exit codes and triggers the retry `on-failure` mechanism of SystemD.