### PR TITLE
No longer require cost_bucket_prefix.

### DIFF
--- a/src/tortuga/resourceAdapter/aws/settings.py
+++ b/src/tortuga/resourceAdapter/aws/settings.py
@@ -295,7 +295,7 @@ SETTINGS = {
     'cost_sync_enabled': settings.BooleanSetting(
         display_name='Cost Synchronization Enabled',
         description='Enable AWS cost synchronization',
-        requires=['cost_bucket_name', 'cost_bucket_prefix'],
+        requires=['cost_bucket_name'],
         **GROUP_COST
     ),
     'cost_bucket_name': settings.StringSetting(


### PR DESCRIPTION
When not set assume all files in the bucket are eligible.