### PR TITLE
Support Spot instance requests on systems not configured for UTC

### DIFF
--- a/src/tortuga/resourceAdapter/aws/aws.py
+++ b/src/tortuga/resourceAdapter/aws/aws.py
@@ -1213,8 +1213,9 @@ class Aws(ResourceAdapter):
 
         # Configured validatity
         duration = configDict.get('spot_request_duration',DEFAULT_SPOT_REQUEST_DURATION)
-        valid_until = (datetime.datetime.now() + datetime.timedelta(seconds=duration)).replace(microsecond=0)
-        args['valid_until'] = valid_until.isoformat()
+        time_now = datetime.datetime.now().astimezone().replace(microsecond=0)
+        expire_at = time_now + datetime.timedelta(seconds=duration)
+        args['valid_until'] = expire_at.isoformat()
 
         return args
 


### PR DESCRIPTION
I prefer the approach of including the timezone in the string (because it's unambiguous) to using `datetime.utcnow`. Both functions ultimately rely on the system-configured timezone.

Resolves #231 