### PR TITLE
Backport AMI validity check to 7.1 branch

### DIFF
--- a/src/tortuga/resourceAdapter/aws/aws.py
+++ b/src/tortuga/resourceAdapter/aws/aws.py
@@ -2269,11 +2269,24 @@ fqdn: %s
 
         is_boto3_conn = isinstance(conn, ServiceResource)
         if is_boto3_conn:
+            # Get image and call load() method to ensure AMI ID is valid;
+            # load() will throw an exception if AMI is invalid.
             ami = conn.Image(image_id)
+            try:
+                ami.load()
+            except Exception as ex:
+                self._logger.error(f"Invalid AMI: {str(ex)}")
+                raise ex
+
+            # Get block devices for AMI
             block_devices = \
                 [bdm['DeviceName'] for bdm in ami.block_device_mappings]
         else:
             ami = conn.get_image(image_id)
+            if ami is None:
+                msg = f"Invalid AMI: image ID {image_id} not found"
+                self._logger.error(msg)
+                raise ConfigurationError(msg)
             block_devices = list(ami.block_device_mapping)
 
         # determine root device name


### PR DESCRIPTION
Make sure AMI exists before attempting to get its block device mappings. Do this for both boto and boto3 connections.

Backport of 76e81e573672e5d5b8644e1eaa2b027df960d8fd.